### PR TITLE
Implement a SportConfig to contain information and service

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -2,26 +2,30 @@
 
 use Avolle\UpcomingMatches\Render\ImageRender;
 use Avolle\UpcomingMatches\Services\ServicesConfig;
+use Avolle\UpcomingMatches\SportConfig;
 
 /*
  * Config
  *
- * teamName - Your team name which will be placed on the rendering
  * url - The URL in which the Excel sheet will be downloaded from. Dates will be appended by the request data
  * renderClass - Which class that will be responsible for rendering the match output. Must implement RenderInterface
  * debug - Whether you are in development mode. If true, stack trace is shown. If false, generic error message is shown
- * services - An array of services that are available to use.
- *      Each key represents a service and each service must be an instance of ServicesConfig
+ * sports - An array of sports that are available to use.
+ *      Each key represents a sport and each sport must be an instance of SportConfig
  */
 return [
-    'teamName' => '',
     'renderClass' => ImageRender::class,
     'debug' => false,
-    'services' => [
-        'football' => new ServicesConfig(
-            'https://some-api.com/request/',
-            ['from' => 'datePeriodFrom', 'to' => 'datePeriodTo'],
-            ['token' => 'some-random-token-provided-by-api', 'clubId' => 666]
+    'sports' => [
+        'football' => new SportConfig(
+            'Fotball',
+            'Aksla IL',
+            'Fotballkamper',
+            new ServicesConfig(
+                'https://www.fotball.no/footballapi/Calendar/DownloadClubExcelCalendar',
+                ['from' => 'fromDate', 'to' => 'toDate'],
+                ['clubId' => 997]
+            )
         ),
     ],
 ];

--- a/public/index.php
+++ b/public/index.php
@@ -12,7 +12,9 @@ require(ROOT . 'vendor/autoload.php');
 require(ROOT . 'functions.php');
 $config = require(ROOT . 'config.php');
 
-setlocale(LC_ALL, 'nb');
+if (!setlocale(LC_ALL, 'nb_NO')) {
+    setlocale(LC_ALL, 'nb');
+};
 
 $log = new Logger('error');
 $log->pushHandler(new StreamHandler(LOGS . 'error.log', Logger::ERROR));

--- a/src/App.php
+++ b/src/App.php
@@ -47,11 +47,11 @@ class App
     protected ServicesInterface $service;
 
     /**
-     * Service's config
+     * Sport's config
      *
-     * @var \Avolle\UpcomingMatches\Services\ServicesConfig
+     * @var \Avolle\UpcomingMatches\SportConfig
      */
-    protected ServicesConfig $serviceConfig;
+    protected SportConfig $sportConfig;
 
     /**
      * App constructor.
@@ -77,11 +77,14 @@ class App
     public function run()
     {
         if (empty($this->requestData)) {
+            $this->view->setVar('sports', $this->appConfig['sports']);
+
             return $this->view->display('form');
         }
 
         $errors = $this->validateRequestData($this->requestData);
         if (!empty($errors)) {
+            $this->view->setVar('sports', $this->appConfig['sports']);
             $this->view->setErrors($errors);
 
             return $this->view->display('form');
@@ -123,18 +126,18 @@ class App
             throw new InvalidSportException($serviceName . ' is not a valid sport.');
         }
 
-        if (!isset($this->appConfig['services'][$sport])) {
+        if (!isset($this->appConfig['sports'][$sport]->serviceConfig)) {
             throw new MissingSportConfigurationException('Missing `' . $sport . '` Service configuration.');
         }
-        if (!$this->appConfig['services'][$sport] instanceof ServicesConfig) {
+        if (!$this->appConfig['sports'][$sport]->serviceConfig instanceof ServicesConfig) {
             throw new MissingSportConfigurationException(
                 'The `' . $sport . '` configuration must be instance of ' . ServicesConfig::class
             );
         }
 
-        $this->serviceConfig = $this->appConfig['services'][$sport];
+        $this->sportConfig = $this->appConfig['sports'][$sport];
 
-        return new $serviceClassName($this->serviceConfig);
+        return new $serviceClassName($this->sportConfig->serviceConfig);
     }
 
     /**
@@ -162,7 +165,7 @@ class App
 
         $matches = collection($matches);
 
-        $renderer = new $renderClass($matches);
+        $renderer = new $renderClass($matches, $this->sportConfig);
 
         if (!$renderer instanceof RenderInterface) {
             throw new InvalidRendererException($renderClass . ' must implement ' . RenderInterface::class);
@@ -208,6 +211,6 @@ class App
      */
     private function validServices()
     {
-        return array_keys($this->appConfig['services']);
+        return array_keys($this->appConfig['sports']);
     }
 }

--- a/src/Render/HtmlRender.php
+++ b/src/Render/HtmlRender.php
@@ -2,6 +2,7 @@
 
 namespace Avolle\UpcomingMatches\Render;
 
+use Avolle\UpcomingMatches\SportConfig;
 use Cake\Collection\CollectionInterface;
 
 class HtmlRender implements RenderInterface
@@ -11,7 +12,7 @@ class HtmlRender implements RenderInterface
      */
     private CollectionInterface $matchesCollection;
 
-    public function __construct(CollectionInterface $matchesCollection)
+    public function __construct(CollectionInterface $matchesCollection, SportConfig $sportConfig)
     {
         $this->matchesCollection = $matchesCollection;
     }

--- a/src/Render/ImageRender.php
+++ b/src/Render/ImageRender.php
@@ -4,6 +4,7 @@ namespace Avolle\UpcomingMatches\Render;
 
 use Avolle\UpcomingMatches\Match;
 use Avolle\UpcomingMatches\Render\Helper\ImageMatchesHelper;
+use Avolle\UpcomingMatches\SportConfig;
 use Cake\Collection\CollectionInterface;
 use Imagick;
 use ImagickDraw;
@@ -12,9 +13,12 @@ use ImagickPixel;
 class ImageRender implements RenderInterface
 {
     private CollectionInterface $matchesCollection;
+    private SportConfig $sportConfig;
+
     private Imagick $imagick;
 
     private ImagickDraw $teamText;
+    private ImagickDraw $sportText;
 
     const BACKGROUND_COLOR = '#C8271A';
 
@@ -22,6 +26,7 @@ class ImageRender implements RenderInterface
     const IMAGE_HEIGHT = 807;
 
     const TEAM_NAME_FONT_SIZE = 46;
+    const SPORT_FONT_SIZE = 30;
 
     const LOGO_POSITION_X = 50;
     const LOGO_POSITION_Y = 100;
@@ -35,9 +40,10 @@ class ImageRender implements RenderInterface
     private float $requiredMatchSizeX = self::MATCH_GRID_X_START;
     private float $requiredMatchSizeY = 0;
 
-    public function __construct(CollectionInterface $matchesCollection)
+    public function __construct(CollectionInterface $matchesCollection, SportConfig $sportConfig)
     {
         $this->matchesCollection = $this->groupByDate($matchesCollection);
+        $this->sportConfig = $sportConfig;
 
         $this->init();
         $this->renderMatches();
@@ -75,6 +81,11 @@ class ImageRender implements RenderInterface
         $this->teamText->setFont(FONTS . 'Roboto-Bold.ttf');
         $this->teamText->setFontSize(self::TEAM_NAME_FONT_SIZE);
         $this->teamText->setFillColor(new ImagickPixel('#FFFFFF'));
+
+        $this->sportText = new ImagickDraw();
+        $this->sportText->setFont(FONTS . 'Roboto-Bold.ttf');
+        $this->sportText->setFontSize(self::SPORT_FONT_SIZE);
+        $this->sportText->setFillColor(new ImagickPixel('#FFFFFF'));
     }
 
     private function renderMatches()
@@ -104,7 +115,8 @@ class ImageRender implements RenderInterface
         $x = self::LOGO_POSITION_X;
         $y = self::LOGO_POSITION_Y;
 
-        $this->imagick->annotateImage($this->teamText, $x, $y, 0, strtoupper('Aksla IL'));
+        $this->imagick->annotateImage($this->teamText, $x, $y, 0, strtoupper($this->sportConfig->teamName));
+        $this->imagick->annotateImage($this->sportText, $x, $y + self::TEAM_NAME_FONT_SIZE, 0, $this->sportConfig->renderSubTitle);
         $logo = new Imagick();
         $logo->readImage(RENDERABLES . 'team-logo-512.png');
         $logo->resizeImage(128, 128, null, 0);

--- a/src/Render/RenderInterface.php
+++ b/src/Render/RenderInterface.php
@@ -2,7 +2,21 @@
 
 namespace Avolle\UpcomingMatches\Render;
 
+use Avolle\UpcomingMatches\SportConfig;
+use Cake\Collection\CollectionInterface;
+
 interface RenderInterface
 {
+    /**
+     * RenderInterface constructor.
+     *
+     * @param \Cake\Collection\CollectionInterface $matches Matches to render
+     * @param \Avolle\UpcomingMatches\SportConfig $sportConfig The sport's config to retrive relevant info about
+     */
+    public function __construct(CollectionInterface $matches, SportConfig $sportConfig);
+
+    /**
+     * Output method. Will output the render
+     */
     public function output(): void;
 }

--- a/src/SportConfig.php
+++ b/src/SportConfig.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Avolle\UpcomingMatches;
+
+use Avolle\UpcomingMatches\Services\ServicesConfig;
+
+class SportConfig
+{
+    public string $sport;
+    public string $teamName;
+    public string $renderSubTitle;
+    public ServicesConfig $serviceConfig;
+
+    public function __construct(string $sport, string $teamName, string $renderSubTitle, ServicesConfig $serviceConfig)
+    {
+        $this->sport = $sport;
+        $this->teamName = $teamName;
+        $this->renderSubTitle = $renderSubTitle;
+        $this->serviceConfig = $serviceConfig;
+    }
+}

--- a/templates/form.php
+++ b/templates/form.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @var \Avolle\UpcomingMatches\View\View $this
+ * @var \Avolle\UpcomingMatches\SportConfig[] $sports
  * @var string|null $infoMessage
  */
 use Cake\Chronos\Chronos;
@@ -38,8 +39,14 @@ use Cake\Chronos\Chronos;
     </div>
     <div>
         <select name="sport" id="sport" required="required">
-            <option value="football" <?= $this->getRequestData('sport') === 'fotball' ? 'selected="selected"' : ''; ?>>Fotball</option>
-            <option value="handball" <?= $this->getRequestData('sport') === 'handball' ? 'selected="selected"' : ''; ?>>Håndball</option>
+            <?php foreach ($sports as $sport => $sportConfig): ?>
+                <option
+                    value="<?= $sport; ?>"
+                    <?= $this->getRequestData('sport') === $sport ? 'selected="selected"' : ''; ?>
+                >
+                    <?= h($sportConfig->sport); ?>
+                </option>
+            <?php endforeach; ?>
         </select>
         <?= $this->Error->message('sport'); ?>
     </div>


### PR DESCRIPTION
When needing to render information about a sport, there was no dynamic way to load said information, as all the information passed was the `ServicesConfig` which does not contain the necessary information. Examples of information is team name, sport name etc.

We've now renamed the Services config array into Sports. This array contains classes of `SportConfig`. The relevant service for that sport is now loaded into the `SportConfig`. As for the rendering class, we've now created a `SportConfig` parameter in the render class, so the class can use the information in the `SportConfig`.