### PR TITLE
Add a callback to filter away unwanted results from the API

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -75,6 +75,7 @@ class App
      * @throws \Avolle\UpcomingMatches\Exception\MissingSportConfigurationException
      * @throws \Avolle\UpcomingMatches\Exception\RuleNotFoundException
      * @throws \Avolle\UpcomingMatches\Exception\MissingViewException
+     * @throws \Avolle\UpcomingMatches\Exception\InvalidFilterableException
      */
     public function run()
     {
@@ -99,6 +100,7 @@ class App
         $this->service->useCache()->fetch($dateFrom, $dateTo);
 
         $matches = $this->service->toArray();
+        $matches = $this->filterMatches($matches);
 
         if (empty($matches)) {
             $this->view->setInfoMessage('Ingen kamper funnet.');
@@ -215,5 +217,21 @@ class App
     private function validServices(): array
     {
         return array_keys($this->appConfig['sports']);
+    }
+
+    /**
+     * Filter matches based on the sports configuration.
+     *
+     * @param array<int, \Avolle\UpcomingMatches\Match> $matches Matches to use in filter
+     * @throws \Avolle\UpcomingMatches\Exception\InvalidFilterableException
+     */
+    protected function filterMatches(array $matches): array
+    {
+        if (!isset($this->sportConfig->filterable)) {
+            return $matches;
+        }
+        $filterable = $this->sportConfig->getFilterableClass();
+
+        return $filterable->filter($matches, $this->sportConfig);
     }
 }

--- a/src/Exception/InvalidFilterableException.php
+++ b/src/Exception/InvalidFilterableException.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace Avolle\UpcomingMatches\Exception;
+
+use Exception;
+
+/**
+ * Class InvalidFilterableException
+ *
+ * @package Avolle\UpcomingMatches\Exception
+ */
+class InvalidFilterableException extends Exception
+{
+}

--- a/src/Filterable/FilterableInterface.php
+++ b/src/Filterable/FilterableInterface.php
@@ -1,0 +1,18 @@
+<?php
+declare(strict_types=1);
+
+namespace Avolle\UpcomingMatches\Filterable;
+
+use Avolle\UpcomingMatches\SportConfig;
+
+interface FilterableInterface
+{
+    /**
+     * Filter matches
+     *
+     * @param array<int, \Avolle\UpcomingMatches\Match> $matches Matches to filter
+     * @param \Avolle\UpcomingMatches\SportConfig $sportConfig SportsConfig to use for filtering
+     * @return array
+     */
+    public function filter(array $matches, SportConfig $sportConfig): array;
+}

--- a/src/Filterable/TeamNameFilter.php
+++ b/src/Filterable/TeamNameFilter.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace Avolle\UpcomingMatches\Filterable;
+
+use Avolle\UpcomingMatches\SportConfig;
+
+class TeamNameFilter implements FilterableInterface
+{
+    /**
+     * Filter matches that do not contain the SportConfig's team name
+     *
+     * @inheritDoc
+     */
+    public function filter(array $matches, SportConfig $sportConfig): array
+    {
+        $spacePos = strpos($sportConfig->teamName, ' ');
+        $teamName = substr($sportConfig->teamName, 0, $spacePos ?: strlen($sportConfig->teamName));
+        $filteredMatches = [];
+        foreach ($matches as $match) {
+            if (strpos($match->homeTeam, $teamName) !== false) {
+                $filteredMatches[] = $match;
+            } elseif (strpos($match->awayTeam, $teamName) !== false) {
+                $filteredMatches[] = $match;
+            }
+        }
+
+        return $filteredMatches;
+    }
+}

--- a/src/SportConfig.php
+++ b/src/SportConfig.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Avolle\UpcomingMatches;
 
+use Avolle\UpcomingMatches\Exception\InvalidFilterableException;
+use Avolle\UpcomingMatches\Filterable\FilterableInterface;
 use Avolle\UpcomingMatches\Services\ServicesConfig;
 
 class SportConfig
@@ -11,12 +13,44 @@ class SportConfig
     public string $teamName;
     public string $renderSubTitle;
     public ServicesConfig $serviceConfig;
+    public ?string $filterable;
 
-    public function __construct(string $sport, string $teamName, string $renderSubTitle, ServicesConfig $serviceConfig)
-    {
+    public function __construct(
+        string $sport,
+        string $teamName,
+        string $renderSubTitle,
+        ServicesConfig $serviceConfig,
+        ?string $filterable = null
+    ) {
         $this->sport = $sport;
         $this->teamName = $teamName;
         $this->renderSubTitle = $renderSubTitle;
         $this->serviceConfig = $serviceConfig;
+        $this->filterable = $filterable;
+    }
+
+    /**
+     * Get a filterable class to use for filtering matches. Returns null if no filter is set
+     *
+     * @return \Avolle\UpcomingMatches\Filterable\FilterableInterface
+     * @throws \Avolle\UpcomingMatches\Exception\InvalidFilterableException
+     */
+    public function getFilterableClass(): ?FilterableInterface
+    {
+        if (!isset($this->filterable)) {
+            return null;
+        }
+
+        $filterClassName = $this->filterable;
+        if (!class_exists($filterClassName)) {
+            throw new InvalidFilterableException($filterClassName . ' is not a valid filter class.');
+        }
+
+        $filterClass = new $filterClassName();
+        if (!$filterClass instanceof FilterableInterface) {
+            throw new InvalidFilterableException($filterClassName . ' must implement ' . FilterableInterface::class);
+        }
+
+        return new $filterClassName();
     }
 }


### PR DESCRIPTION
Through the configuration you can define a Filterable class using the `FilterableInterface` to remove unwanted results from the API.

This is in preparation of gathering matches from clubs that cooperate with the main club. This leaves us with all the matches from that club, but with this PR we can filter away those results that do not involve the main club.