### PR TITLE
Remove duplicates

### DIFF
--- a/src/Filterable/TeamNameFilter.php
+++ b/src/Filterable/TeamNameFilter.php
@@ -19,9 +19,9 @@ class TeamNameFilter implements FilterableInterface
         $filteredMatches = [];
         foreach ($matches as $match) {
             if (strpos($match->homeTeam, $teamName) !== false) {
-                $filteredMatches[] = $match;
+                $filteredMatches[$match->matchId] = $match;
             } elseif (strpos($match->awayTeam, $teamName) !== false) {
-                $filteredMatches[] = $match;
+                $filteredMatches[$match->matchId] = $match;
             }
         }
 

--- a/src/Match.php
+++ b/src/Match.php
@@ -62,6 +62,13 @@ class Match
     public string $tournament;
 
     /**
+     * Id of match
+     *
+     * @var string
+     */
+    public string $matchId;
+
+    /**
      * Match constructor.
      *
      * @param \DateTime $date Date
@@ -71,6 +78,7 @@ class Match
      * @param string $awayTeam Away team
      * @param string $pitch Pitch
      * @param string $tournament Tournament
+     * @param string $matchId Match id
      */
     public function __construct(
         DateTime $date,
@@ -79,7 +87,8 @@ class Match
         string $homeTeam,
         string $awayTeam,
         string $pitch,
-        string $tournament
+        string $tournament,
+        string $matchId
     ) {
         $this->date = $date;
         $this->day = $day;
@@ -88,5 +97,6 @@ class Match
         $this->awayTeam = trim($awayTeam);
         $this->pitch = trim($pitch);
         $this->tournament = trim($tournament);
+        $this->matchId = trim($matchId);
     }
 }

--- a/src/Services/HandballService.php
+++ b/src/Services/HandballService.php
@@ -53,7 +53,8 @@ class HandballService extends Service
                 $match['Hjemmelag'],
                 $match['Bortelag'],
                 $match['Bane'],
-                $match['Turnering']
+                $match['Turnering'],
+                $match['Kampnr']
             );
         }
 

--- a/src/SpreadsheetReader.php
+++ b/src/SpreadsheetReader.php
@@ -34,6 +34,7 @@ class SpreadsheetReader
             'awayTeam' => 'G',
             'pitch' => 'H',
             'tournament' => 'I',
+            'matchId' => 'J',
         ],
     ];
 
@@ -97,6 +98,7 @@ class SpreadsheetReader
                     $spreadsheet->getCell($this->cell($this->options['headers']['awayTeam'], $row))->getValue(),
                     $spreadsheet->getCell($this->cell($this->options['headers']['pitch'], $row))->getValue(),
                     $spreadsheet->getCell($this->cell($this->options['headers']['tournament'], $row))->getValue(),
+                    $spreadsheet->getCell($this->cell($this->options['headers']['matchId'], $row))->getValue(),
                 );
             } catch (Exception $e) {
                 throw new InvalidExcelConfiguration();


### PR DESCRIPTION
With #19 we allowed pulling matches from several sources, due to clubs merging certain teams (cooperation). This PR introduced a bug whereby matches between these cooperating teams were showed twice. This PR solves the duplications through a match id index.