### PR TITLE
Add correct sorting to all services

### DIFF
--- a/src/Services/FootballService.php
+++ b/src/Services/FootballService.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Avolle\UpcomingMatches\Services;
 
+use Avolle\UpcomingMatches\Game;
 use Avolle\UpcomingMatches\SpreadsheetReader;
 
 /**
@@ -29,7 +30,10 @@ class FootballService extends Service
             ));
         }
 
-        return $results->toArray(false);
+        return $results
+            ->sortBy(fn (Game $match) => $match->time, SORT_ASC)
+            ->sortBy(fn (Game $match) => $match->date, SORT_ASC)
+            ->toArray(false);
     }
 
     /**

--- a/src/Services/HandballService.php
+++ b/src/Services/HandballService.php
@@ -23,7 +23,10 @@ class HandballService extends Service
             $results = $results->append($this->extractResult($result));
         }
 
-        return $results->sortBy(fn(Game $match) => $match->date, SORT_ASC)->toArray(false);
+        return $results
+            ->sortBy(fn (Game $match) => $match->time, SORT_ASC)
+            ->sortBy(fn (Game $match) => $match->date, SORT_ASC)
+            ->toArray(false);
     }
 
     /**


### PR DESCRIPTION
Using multiple teams as match resources in the `FootballService` matches were not sorted properly.

All matches for a single team was sorted correctly, but the following teams were only added to the end of nth teams matches.

This PR sorts all matches by time and then date after fetching all matches.